### PR TITLE
[RelEng] Fix tagging and PR creation in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@
 #     Hannes Wellmann (IILS mbH) - initial API and implementation
 ###############################################################################
 name: Release
-
 # Releases the main branch with as version currently configured in the parent pom, assuming it aligns with the targeted upstream Eclipse-Passage release.
 
 on:
@@ -32,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       actions: read
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -74,9 +74,9 @@ jobs:
           --expression="s|[[:digit:]]\+_[[:digit:]]\+_[[:digit:]]\+|${VERSION_DASHSED}|g" \
           README.md
         
-        # Commit updated README and add release tag
-        git commit --all --message="Release ${RELEASE_TAG}"
+        # Commit updated README and add release tag (use current HEAD as new commits will be rebased on submission)
         git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+        git commit --all --message="Release ${RELEASE_TAG}"
         
         # Prepare next development cycle
         export NEW_VERSION="${VERSION%.*}.$((${VERSION##*.}+1))"
@@ -107,4 +107,4 @@ jobs:
         branchName="release_${VERSION}"
         git push origin HEAD:refs/heads/${branchName}
         gh pr create --base main --head ${branchName} \
-          --title "Release ${VERSION}" --body "Complete ${VERSION} release and prepare for next development iteration" 
+          --title "Release ${VERSION}" --body "Complete ${VERSION} release and prepare for next development iteration." 


### PR DESCRIPTION
Previously the release-tag was added to the release commit (updating the README), but as this PR is usually altered in the PR-submission process, eventually the tag was off the linear history.
Now simply the current main branch head of the time when the workflow is started is tagged, which is the commit before the release commit. That's also the commit from which the release artifacts are build.

Also add missing permissions for the final PR creation step.